### PR TITLE
Fixed error in BTCH weight calculation

### DIFF
--- a/BTCH_calculation_v1.m
+++ b/BTCH_calculation_v1.m
@@ -23,13 +23,13 @@ Deno_result=zeros(hs,ls);
 for num = 1:size(Std_data_ori,3)
     Std_data = Std_data_ori;
     Std_data(:,:,num)=[];
-    tem_data = cumprod(Std_data,3);
+    tem_data = cumprod(Std_data.^2,3);
     Deno_result = Deno_result+tem_data(:,:,end);
 end
 for num = 1:size(Std_data_ori,3)
     Std_data = Std_data_ori;
     Std_data(:,:,num)=[];
-    tem_data = cumprod(Std_data,3);
+    tem_data = cumprod(Std_data.^2,3);
     Weight_data(:,:,num) = tem_data(:,:,end)./Deno_result;
 end
 


### PR DESCRIPTION
Firstly, thanks for making the BTCH code public, it's very useful to me!

According to **He et al. (2020)**, the weights for each data set were calculated as follows:

$$
w_k = \frac{\prod\limits_{i=1, i \neq k}^{N} \sigma_i^2}{\sum\limits_{k=1}^{N} \left( \prod\limits_{i=1, i \neq k}^{N} \sigma_i^2 \right)} \tag{1}
$$

The **error covariance ($\sigma_i$)** of each data set can be obtained using the three-cornered hat (TCH) method.

In `BTCH_calculation_v1.m` script, the code for the cumulative product is as follows:

https://github.com/xutr-bnu/TCH_method/blob/d975940162cc60b570404a7be2481a30877e9a88/BTCH_calculation_v1.m#L26
https://github.com/xutr-bnu/TCH_method/blob/d975940162cc60b570404a7be2481a30877e9a88/BTCH_calculation_v1.m#L32

where `Std_data` is the cumulative product of `std` from the `TCH_main()` outputs. **Based on Eq. (1), I think `Std_data` should be changed to `Std_data.^2`.** This oversight has a noticeable effect on the result of the weight assignment.

**Reference:**
He, X., Xu, T., Xia, Y., Bateni, S.M., Guo, Z., Liu, S., Mao, K., Zhang, Y., Feng, H., Zhao, J., 2020. A Bayesian Three-Cornered Hat (BTCH) Method: Improving the Terrestrial Evapotranspiration Estimation. Remote Sensing 12, 878. https://doi.org/10.3390/rs12050878
